### PR TITLE
Fix singular DELETE response consistency

### DIFF
--- a/src/http/app.ts
+++ b/src/http/app.ts
@@ -216,7 +216,7 @@ export function createApp(store: SqliteStore, options: AppOptions = {}): express
       return;
     }
 
-    res.json({});
+    res.json(removed);
   });
 
   app.use((_req, res) => {

--- a/src/storage/sqliteStore.ts
+++ b/src/storage/sqliteStore.ts
@@ -198,9 +198,14 @@ export class SqliteStore {
     return next;
   }
 
-  public deleteSingular(resource: string): boolean {
-    const result = this.db.prepare('DELETE FROM singular WHERE resource = ?;').run(resource);
-    return result.changes > 0;
+  public deleteSingular(resource: string): JsonObject | null {
+    const existing = this.getSingular(resource);
+    if (!existing) {
+      return null;
+    }
+
+    this.db.prepare('DELETE FROM singular WHERE resource = ?;').run(resource);
+    return existing;
   }
 
   public async exportToJsonFile(targetPath = this.sourcePath): Promise<void> {

--- a/test/http.integration.test.ts
+++ b/test/http.integration.test.ts
@@ -83,4 +83,13 @@ describe('http integration', () => {
     const patched = await request(app).patch('/profile').send({ role: 'admin' }).expect(200);
     expect(patched.body).toEqual({ name: 'typicode', role: 'admin' });
   });
+
+  it('returns deleted singular object on delete', async () => {
+    const app = createApp(store);
+
+    const removed = await request(app).delete('/profile').expect(200);
+    expect(removed.body).toEqual({ name: 'typicode' });
+
+    await request(app).delete('/profile').expect(404);
+  });
 });


### PR DESCRIPTION
## Summary
- make deleteSingular return the removed object instead of a boolean
- return that object from DELETE /:resource for singular resources
- add integration test for singular delete response and repeated delete 404

## Testing
- 
pm test -- test/http.integration.test.ts

Closes #6