### PR TITLE
Simplify file watcher debounce

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ coverage/
 .env
 .DS_Store
 *.log
+llm devnotes.md

--- a/src/storage/watch.ts
+++ b/src/storage/watch.ts
@@ -5,7 +5,6 @@ export interface FileWatcher {
 }
 
 export function watchFile(path: string, onChange: () => Promise<void>): FileWatcher {
-  let timer: NodeJS.Timeout | undefined;
   const watcher = chokidar.watch(path, {
     ignoreInitial: true,
     awaitWriteFinish: {
@@ -15,20 +14,11 @@ export function watchFile(path: string, onChange: () => Promise<void>): FileWatc
   });
 
   watcher.on('change', () => {
-    if (timer) {
-      clearTimeout(timer);
-    }
-
-    timer = setTimeout(() => {
-      void onChange();
-    }, 150);
+    void onChange();
   });
 
   return {
     async close() {
-      if (timer) {
-        clearTimeout(timer);
-      }
       await watcher.close();
     }
   };


### PR DESCRIPTION
## Summary
- remove extra timer-based debounce in watchFile
- rely on chokidar waitWriteFinish for write stabilization
- simplify watcher teardown by removing timer cleanup path

## Testing
- 
pm test

Closes #9